### PR TITLE
Updates CORS policy to allow additional origin

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -43,7 +43,7 @@ server {
         
         # Tratar requisições preflight OPTIONS
         if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' 'http://localhost:9000' always;
+            add_header 'Access-Control-Allow-Origin' 'http://localhost:9000', 'https://q-cadastro.vercel.app' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization' always;
             add_header 'Access-Control-Allow-Credentials' 'true' always;


### PR DESCRIPTION
Adds 'https://q-cadastro.vercel.app' to the list of allowed origins in the CORS configuration for OPTIONS preflight requests.

Enhances compatibility for requests from the new client application.